### PR TITLE
Remove bridge image from startHere and contributor pages

### DIFF
--- a/html/bios.html
+++ b/html/bios.html
@@ -53,13 +53,6 @@
       <!-- The HTML here is generated in the main.js file -->
     </nav>
     <section class="main-section-wrapper">
-      <div class="main-page">
-        <img
-          class="header-img"
-          src="../img/GoldenGateBridge.jpg"
-          SameSite="none Secure"
-        />
-      </div>
       <div class="container page-format">
         <section class="main-section">
           <h1>Contributors</h1>

--- a/html/startHere.html
+++ b/html/startHere.html
@@ -53,13 +53,6 @@
       <!-- The HTML here is generated in the main.js file -->
     </nav>
     <section class="main-section-wrapper">
-      <div class="main-page">
-        <img
-          class="header-img"
-          src="../img/GoldenGateBridge.jpg"
-          SameSite="none Secure"
-        />
-      </div>
       <div class="container page-format">
         <section class="main-section">
           <h1>Happy New Year!</h1>


### PR DESCRIPTION
I removed the header image from the startHere and contributor pages per issue #59, but I left the one on the contact page (contact.html) since it doesn't seem to be linked anywhere.